### PR TITLE
Content Whitelist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,25 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/me/minoneer/bukkit/bookexploit/BookExploitFix.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/BookExploitFix.java
@@ -20,7 +20,7 @@ public final class BookExploitFix extends JavaPlugin {
     public void onEnable() {
         final ConfigHandler config = loadConfig();
 
-        final BookFilter filter = new BookFilter(config.getFilterActions(), getLogger());
+        final BookFilter filter = new BookFilter(config.getFilterActions(), config, getLogger());
 
         registerCommands(filter);
 

--- a/src/main/java/me/minoneer/bukkit/bookexploit/BookFilter.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/BookFilter.java
@@ -3,6 +3,7 @@ package me.minoneer.bukkit.bookexploit;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -19,14 +20,21 @@ public final class BookFilter {
 
     private final Logger logger;
     private final Set<ClickEvent.Action> filterActions;
+    private final ConfigHandler config;
 
-    public BookFilter(@NotNull final Set<ClickEvent.Action> filterActions, @NotNull final Logger logger) {
+    public BookFilter(
+            @NotNull final Set<ClickEvent.Action> filterActions,
+            @NotNull final ConfigHandler config,
+            @NotNull final Logger logger
+    ) {
         this.filterActions = filterActions;
+        this.config = config;
         this.logger = logger;
     }
 
     @Nullable
-    public ItemStack filterBook(@Nullable final ItemStack originalItem) {
+    public ItemStack filterBook(@Nullable final ItemStack originalItem, @NotNull final Player player) {
+
         if (originalItem == null) {
             return null;
         }
@@ -42,7 +50,7 @@ public final class BookFilter {
             return null;
         }
 
-        final BookMeta filteredBookMeta = filterBookMeta((BookMeta) itemMeta);
+        final BookMeta filteredBookMeta = filterBookMeta((BookMeta) itemMeta, player);
 
         if (filteredBookMeta != null) {
             newItem.setItemMeta(filteredBookMeta);
@@ -53,7 +61,11 @@ public final class BookFilter {
     }
 
     @Nullable
-    public BookMeta filterBookMeta(@NotNull final BookMeta bookMeta) {
+    public BookMeta filterBookMeta(@NotNull final BookMeta bookMeta, @NotNull final Player player) {
+        if (config.isWorldDisabled(player.getWorld())) {
+            return null;
+        }
+
         // Spigot returns an anonymous object inheriting from AbstractList, which lazily parses each page on access.
         // This has the side-effect that each get(i) method returns a new object parsed from the original, overwriting
         // any modifications to the old reference. Since we need all pages anyway, we just store them in a regular list.

--- a/src/main/java/me/minoneer/bukkit/bookexploit/BookFilter.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/BookFilter.java
@@ -33,8 +33,11 @@ public final class BookFilter {
     }
 
     @Nullable
-    public ItemStack filterBook(@Nullable final ItemStack originalItem, @NotNull final Player player) {
-
+    public ItemStack filterBook(
+            @Nullable final ItemStack originalItem,
+            @NotNull final Player player,
+            @NotNull final FilterAction action
+    ) {
         if (originalItem == null) {
             return null;
         }
@@ -50,7 +53,7 @@ public final class BookFilter {
             return null;
         }
 
-        final BookMeta filteredBookMeta = filterBookMeta((BookMeta) itemMeta, player);
+        final BookMeta filteredBookMeta = filterBookMeta((BookMeta) itemMeta, player, action);
 
         if (filteredBookMeta != null) {
             newItem.setItemMeta(filteredBookMeta);
@@ -61,8 +64,18 @@ public final class BookFilter {
     }
 
     @Nullable
-    public BookMeta filterBookMeta(@NotNull final BookMeta bookMeta, @NotNull final Player player) {
+    public BookMeta filterBookMeta(
+            @NotNull final BookMeta bookMeta,
+            @NotNull final Player player,
+            @NotNull final FilterAction action
+    ) {
         if (config.isWorldDisabled(player.getWorld())) {
+            return null;
+        }
+        if (!config.checkAction(action)) {
+            return null;
+        }
+        if (action == FilterAction.CREATE && player.hasPermission("bookexploitfix.exempt")) {
             return null;
         }
 

--- a/src/main/java/me/minoneer/bukkit/bookexploit/BookFilter.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/BookFilter.java
@@ -96,10 +96,13 @@ public final class BookFilter {
         boolean componentFiltered = false;
         final ClickEvent clickEvent = component.getClickEvent();
         if (clickEvent != null && this.filterActions.contains(clickEvent.getAction())) {
-            component.setClickEvent(null);
-            componentFiltered = true;
-            logger.log(Level.WARNING, "Filtered illegal content from item!");
-            logger.log(Level.WARNING, BookExploitFix.limitLoggingString(clickEvent.toString()));
+            String content = clickEvent.getValue();
+            if (!config.isContentPermitted(content)) {
+                component.setClickEvent(null);
+                componentFiltered = true;
+                logger.log(Level.WARNING, "Filtered illegal content from item!");
+                logger.log(Level.WARNING, BookExploitFix.limitLoggingString(clickEvent.toString()));
+            }
         }
         final List<BaseComponent> extra = component.getExtra();
         if (extra != null) {

--- a/src/main/java/me/minoneer/bukkit/bookexploit/BookListener.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/BookListener.java
@@ -33,11 +33,8 @@ public final class BookListener implements Listener {
         if (!config.checkCreation()) {
             return;
         }
-        if (config.isWorldDisabled(player.getWorld())) {
-            return;
-        }
 
-        final BookMeta filteredBookMeta = bookFilter.filterBookMeta(event.getNewBookMeta());
+        final BookMeta filteredBookMeta = bookFilter.filterBookMeta(event.getNewBookMeta(), player);
         if (filteredBookMeta != null) {
             logger.log(Level.WARNING, "Player {0} {1} tried to create a book with illegal click events!",
                     new Object[]{player.getName(), player.getUniqueId()});
@@ -54,9 +51,6 @@ public final class BookListener implements Listener {
         if (!config.checkReading()) {
             return;
         }
-        if (config.isWorldDisabled(player.getWorld())) {
-            return;
-        }
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
@@ -68,7 +62,7 @@ public final class BookListener implements Listener {
             toFilter = player.getInventory().getItemInMainHand();
         }
 
-        final ItemStack filtered = bookFilter.filterBook(toFilter);
+        final ItemStack filtered = bookFilter.filterBook(toFilter, player);
 
         if (filtered != null) {
             logger.log(Level.WARNING, "Player {0} {1} tried to read a book with illegal click events!",

--- a/src/main/java/me/minoneer/bukkit/bookexploit/BookListener.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/BookListener.java
@@ -30,11 +30,7 @@ public final class BookListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onBookEdit(@NotNull final PlayerEditBookEvent event) {
         final Player player = event.getPlayer();
-        if (!config.checkCreation()) {
-            return;
-        }
-
-        final BookMeta filteredBookMeta = bookFilter.filterBookMeta(event.getNewBookMeta(), player);
+        final BookMeta filteredBookMeta = bookFilter.filterBookMeta(event.getNewBookMeta(), player, FilterAction.CREATE);
         if (filteredBookMeta != null) {
             logger.log(Level.WARNING, "Player {0} {1} tried to create a book with illegal click events!",
                     new Object[]{player.getName(), player.getUniqueId()});
@@ -48,9 +44,6 @@ public final class BookListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onBookRead(@NotNull final PlayerInteractEvent event) {
         final Player player = event.getPlayer();
-        if (!config.checkReading()) {
-            return;
-        }
         if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
@@ -62,7 +55,7 @@ public final class BookListener implements Listener {
             toFilter = player.getInventory().getItemInMainHand();
         }
 
-        final ItemStack filtered = bookFilter.filterBook(toFilter, player);
+        final ItemStack filtered = bookFilter.filterBook(toFilter, player, FilterAction.READ);
 
         if (filtered != null) {
             logger.log(Level.WARNING, "Player {0} {1} tried to read a book with illegal click events!",

--- a/src/main/java/me/minoneer/bukkit/bookexploit/ConfigHandler.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/ConfigHandler.java
@@ -23,6 +23,7 @@ public final class ConfigHandler {
     private static final String PATH_FILTER_CONTENT = "filter_content";
     private static final String PATH_CHECK_CREATION = "check_actions.book_creation";
     private static final String PATH_CHECK_READING = "check_actions.book_reading";
+    private static final String PATH_PERMITTED_CONTENT = "permitted_content";
     private static final String PATH_WORLD_WHITELIST = "world_whitelist";
     private static final String PATH_PLAYER_MESSAGE = "player_message";
 
@@ -34,6 +35,7 @@ public final class ConfigHandler {
     private boolean checkCreation;
     private boolean checkReading;
     private List<String> worldWhitelist;
+    private WildcardMatcher permittedContent;
     private String playerMessage;
 
     public ConfigHandler(@NotNull final Plugin plugin) {
@@ -75,6 +77,8 @@ public final class ConfigHandler {
         List<String> worldWhiteList = config.getStringList(PATH_WORLD_WHITELIST);
         this.worldWhitelist = worldWhiteList.isEmpty() ? null : worldWhiteList;
 
+        this.permittedContent = new WildcardMatcher(config.getStringList(PATH_PERMITTED_CONTENT));
+
         final String rawMessage = config.getString(PATH_PLAYER_MESSAGE);
         if (rawMessage != null && !rawMessage.trim().isEmpty()) {
             this.playerMessage = ChatColor.translateAlternateColorCodes('&', rawMessage);
@@ -98,6 +102,10 @@ public final class ConfigHandler {
 
     public boolean isWorldDisabled(World world) {
         return this.worldWhitelist != null && !this.worldWhitelist.contains(world.getName());
+    }
+
+    public boolean isContentPermitted(String content) {
+        return permittedContent.matches(content);
     }
 
     @Nullable

--- a/src/main/java/me/minoneer/bukkit/bookexploit/ConfigHandler.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/ConfigHandler.java
@@ -92,14 +92,6 @@ public final class ConfigHandler {
         return filterActions;
     }
 
-    public boolean checkCreation() {
-        return checkCreation;
-    }
-
-    public boolean checkReading() {
-        return checkReading;
-    }
-
     public boolean isWorldDisabled(World world) {
         return this.worldWhitelist != null && !this.worldWhitelist.contains(world.getName());
     }
@@ -111,5 +103,16 @@ public final class ConfigHandler {
     @Nullable
     public String getPlayerMessage() {
         return playerMessage;
+    }
+
+    public boolean checkAction(FilterAction action) {
+        switch (action) {
+            case READ:
+                return checkReading;
+            case CREATE:
+                return checkCreation;
+            default:
+                return true;
+        }
     }
 }

--- a/src/main/java/me/minoneer/bukkit/bookexploit/FilterAction.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/FilterAction.java
@@ -1,0 +1,18 @@
+package me.minoneer.bukkit.bookexploit;
+
+public enum FilterAction {
+    /**
+     * Represents the creation of a book, either via ingame mechanics or creative inventory actions
+     */
+    CREATE,
+
+    /**
+     * Represents the reading of a book, e.g. by holding it or on a lectern
+     */
+    READ,
+
+    /**
+     * Explicitly filter by invoking the command
+     */
+    COMMAND
+}

--- a/src/main/java/me/minoneer/bukkit/bookexploit/FilterCommand.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/FilterCommand.java
@@ -40,7 +40,7 @@ public final class FilterCommand implements CommandExecutor {
             return true;
         }
 
-        final ItemStack newBook = bookFilter.filterBook(book);
+        final ItemStack newBook = bookFilter.filterBook(book, player);
         if (newBook != null) {
             player.getInventory().addItem(newBook);
             sender.sendMessage(ChatColor.AQUA + "A filtered version of this book has been added to your inventory");

--- a/src/main/java/me/minoneer/bukkit/bookexploit/FilterCommand.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/FilterCommand.java
@@ -40,7 +40,7 @@ public final class FilterCommand implements CommandExecutor {
             return true;
         }
 
-        final ItemStack newBook = bookFilter.filterBook(book, player);
+        final ItemStack newBook = bookFilter.filterBook(book, player, FilterAction.COMMAND);
         if (newBook != null) {
             player.getInventory().addItem(newBook);
             sender.sendMessage(ChatColor.AQUA + "A filtered version of this book has been added to your inventory");

--- a/src/main/java/me/minoneer/bukkit/bookexploit/LecternListener.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/LecternListener.java
@@ -40,13 +40,10 @@ public final class LecternListener implements Listener {
         if (clickedBlock == null || clickedBlock.getType() != Material.LECTERN) {
             return;
         }
-        if (config.isWorldDisabled(clickedBlock.getWorld())) {
-            return;
-        }
 
         Lectern lectern = (Lectern) clickedBlock.getState();
         final ItemStack toFilter = lectern.getInventory().getItem(0);
-        final ItemStack filtered = bookFilter.filterBook(toFilter);
+        final ItemStack filtered = bookFilter.filterBook(toFilter, player);
 
         if (filtered != null) {
             logger.log(Level.WARNING, "Player {0} {1} tried to read a lectern book with illegal click events!",

--- a/src/main/java/me/minoneer/bukkit/bookexploit/LecternListener.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/LecternListener.java
@@ -30,9 +30,6 @@ public final class LecternListener implements Listener {
     @EventHandler(priority = EventPriority.LOW)
     public void onLecternRead(@NotNull final PlayerInteractEvent event) {
         final Player player = event.getPlayer();
-        if (!config.checkReading()) {
-            return;
-        }
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
             return;
         }
@@ -43,7 +40,7 @@ public final class LecternListener implements Listener {
 
         Lectern lectern = (Lectern) clickedBlock.getState();
         final ItemStack toFilter = lectern.getInventory().getItem(0);
-        final ItemStack filtered = bookFilter.filterBook(toFilter, player);
+        final ItemStack filtered = bookFilter.filterBook(toFilter, player, FilterAction.READ);
 
         if (filtered != null) {
             logger.log(Level.WARNING, "Player {0} {1} tried to read a lectern book with illegal click events!",

--- a/src/main/java/me/minoneer/bukkit/bookexploit/ProtocolLibHook.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/ProtocolLibHook.java
@@ -21,9 +21,6 @@ public final class ProtocolLibHook {
             final ConfigHandler config,
             final Logger logger
     ) {
-        if (!config.checkCreation()) {
-            return;
-        }
         ProtocolManager manager = ProtocolLibrary.getProtocolManager();
         manager.addPacketListener(new PacketAdapter(plugin, ListenerPriority.LOW,
                 PacketType.Play.Client.SET_CREATIVE_SLOT
@@ -32,7 +29,7 @@ public final class ProtocolLibHook {
             public void onPacketReceiving(PacketEvent event) {
                 final Player player = event.getPlayer();
                 ItemStack item = event.getPacket().getItemModifier().readSafely(0);
-                ItemStack filteredItem = bookFilter.filterBook(item, player);
+                ItemStack filteredItem = bookFilter.filterBook(item, player, FilterAction.CREATE);
                 if (filteredItem != null) {
                     event.setCancelled(true);
                     event.getPlayer().updateInventory();

--- a/src/main/java/me/minoneer/bukkit/bookexploit/ProtocolLibHook.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/ProtocolLibHook.java
@@ -31,11 +31,8 @@ public final class ProtocolLibHook {
             @Override
             public void onPacketReceiving(PacketEvent event) {
                 final Player player = event.getPlayer();
-                if (config.isWorldDisabled(player.getWorld())) {
-                    return;
-                }
                 ItemStack item = event.getPacket().getItemModifier().readSafely(0);
-                ItemStack filteredItem = bookFilter.filterBook(item);
+                ItemStack filteredItem = bookFilter.filterBook(item, player);
                 if (filteredItem != null) {
                     event.setCancelled(true);
                     event.getPlayer().updateInventory();

--- a/src/main/java/me/minoneer/bukkit/bookexploit/WildcardMatcher.java
+++ b/src/main/java/me/minoneer/bukkit/bookexploit/WildcardMatcher.java
@@ -1,0 +1,50 @@
+package me.minoneer.bukkit.bookexploit;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class WildcardMatcher {
+
+    private final List<Pattern> patterns;
+
+    public WildcardMatcher(@NotNull final Collection<String> wildcards) {
+        this.patterns = wildcards
+                .stream()
+                .map(WildcardMatcher::convertToRegex)
+                .map(regex -> Pattern.compile(regex, Pattern.CASE_INSENSITIVE))
+                .collect(Collectors.toList());
+    }
+
+    public boolean matches(@Nullable String value) {
+        if (value == null) {
+            return false;
+        }
+        for (Pattern pattern : patterns) {
+            if (pattern.matcher(value.trim()).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String convertToRegex(String wildcardString) {
+        Pattern pattern = Pattern.compile("[^*]+|(\\*)");
+        Matcher matcher = pattern.matcher(wildcardString);
+        StringBuffer regex = new StringBuffer();
+        while (matcher.find()) {
+            if (matcher.group(1) != null) {
+                matcher.appendReplacement(regex, ".*");
+            } else {
+                matcher.appendReplacement(regex, "\\\\Q" + matcher.group(0) + "\\\\E");
+            }
+        }
+        matcher.appendTail(regex);
+        return regex.toString();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,6 +29,14 @@
 #    # Checks content when a player reads a book, either from their inventory or on a lectern.
 #    book_reading: true
 #
+#  # A white list of content which is permitted and will not be removed during checks. This can for example be
+#  # commands or URLs which you wish to allow in books. The * wildcard is supported and will match any sequence
+#  # of characters. Be careful where to place it. '/*' for example will match any command and effectively disable
+#  # the check!
+#  permitted_content:
+#    - '/help'
+#    - 'https://www.minecraft.net/*'
+#
 #  # Restricts all checks to selected worlds only. This value is optional and absent by default, which means
 #  # checks are active in all worlds. An empty list or null will enable checks in all worlds as well.
 #  world_whitelist:

--- a/src/test/java/me/minoneer/bukkit/bookexploit/WildcardMatcherTest.java
+++ b/src/test/java/me/minoneer/bukkit/bookexploit/WildcardMatcherTest.java
@@ -1,0 +1,43 @@
+package me.minoneer.bukkit.bookexploit;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class WildcardMatcherTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test", "Test", "  test ", "tEST", "test1", ".", "?"})
+    public void matchCorrectRegularStrings(String value) {
+        WildcardMatcher matcher = new WildcardMatcher(Arrays.asList("test", "Test1", ".", "?"));
+        assertTrue(matcher.matches(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test1", "", " ", "!", "a", "*"})
+    @NullSource
+    public void matchIncorrectRegularStrings(String value) {
+        WildcardMatcher matcher = new WildcardMatcher(Arrays.asList("test", ".", "?"));
+        assertFalse(matcher.matches(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"test", "Test", "  test ", "tEST", "test1", "Test Two", "Tests", "foobar", "foo and bar"})
+    public void matchCorrectWildcardStrings(String value) {
+        WildcardMatcher matcher = new WildcardMatcher(Arrays.asList("test*", "Foo*Bar"));
+        assertTrue(matcher.matches(value));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1test", "", " ", "random", "Foo", "bar", "*"})
+    @NullSource
+    public void matchIncorrectWildcardStrings(String value) {
+        WildcardMatcher matcher = new WildcardMatcher(Arrays.asList("test*", "Foo*Bar"));
+        assertFalse(matcher.matches(value));
+    }
+}


### PR DESCRIPTION
Add the option to specify a white list of content which is allowed in click events. It supports `*` wildcards to match any string.

Add override permission to allow book creation without filtering content. Note that there is no such permission for reading books as this would defeat the purpose of protecting OPs from malicious books.